### PR TITLE
fixed swapping of elements.

### DIFF
--- a/src/QuickMedianLib.h
+++ b/src/QuickMedianLib.h
@@ -53,7 +53,7 @@ T QuickMedian<T>::kthSmallest(T* data, int dataLength, int kth)
 			{
 				T t = data[j];
 				data[j] = data[i];
-				data[i] = data[j];
+				data[i] = t;
 				i++;
 				j--;
 			}


### PR DESCRIPTION
This took me some time to find and fix. Your swapping function does not swap, but just writes data[i] to both data[i] and data[j]. Can you make sure it gets updated in the arduino library which is found when looking for "median" in the arduino IDE? Is that automatically taken from github? 